### PR TITLE
refactor: drop ember-functional-modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
-ember-style-modifier
-==============================================================================
+# ember-style-modifier
 
 [![Build Status](https://travis-ci.org/jelhan/ember-style-modifier.svg?branch=master)](https://travis-ci.org/jelhan/ember-style-modifier)
 
 This addon provides a `{{style}}` element modifier to set element's style.
 This allows to set custom CSS of an element without requiring a [Content Security Policy](https://content-security-policy.com/) `style-src-attr: "unsafe-inline"`.
 
-Compatibility
-------------------------------------------------------------------------------
+## Compatibility
 
-It supports the same versions as [`ember-functional-modifiers`](https://github.com/spencer516/ember-functional-modifiers#compatibility) does.
+It supports the same versions as [`ember-modifier-manager-polyfill`](https://github.com/rwjblue/ember-modifier-manager-polyfill#compatibility) does.
 
-Installation
-------------------------------------------------------------------------------
+## Installation
 
 ```sh
 ember install ember-style-modifier
 ```
 
-Usage
-------------------------------------------------------------------------------
+## Usage
 
 It expects CSS declarations as named arguments or as a hash as first positional
 argument. Property names are supported in dasherized as well as in camelCase
@@ -45,16 +41,12 @@ adding an `"!important"` suffix.
 If option hash and named arguments contain CSS declarations for the same
 property, named argument wins.
 
-Attaching style modifier multiple times to the same element is not supported.
-
 Adding styles to pseudo-elements is not supported.
 
-Contributing
-------------------------------------------------------------------------------
+## Contributing
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/addon/modifiers/style.js
+++ b/addon/modifiers/style.js
@@ -12,7 +12,7 @@ const getStylesFromOptions = (positional, named) =>
 function setStyles(element, newStyles, oldStyles) {
   const rulesToRemove = oldStyles ? new Set(Object.keys(oldStyles)) : null;
 
-  for (let [property, value] of Object.entries(newStyles)) {
+  Object.entries(newStyles).forEach(([property, value]) => {
     assert(
       `Value must be a string or undefined, ${typeOf(value)} given`,
       typeof value === 'undefined' || typeOf(value) === 'string'
@@ -34,12 +34,10 @@ function setStyles(element, newStyles, oldStyles) {
     if (rulesToRemove) {
       rulesToRemove.delete(property);
     }
-  }
+  });
 
   if (rulesToRemove) {
-    for (const rule of rulesToRemove) {
-      element.style.removeProperty(rule);
-    }
+    rulesToRemove.forEach(rule => element.style.removeProperty(rule));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-style-modifier",
   "version": "0.3.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "{{style}} modifier to set an element's style using the CSSStyleDeclaration API.",
   "keywords": [
     "ember-addon"
   ],
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
-    "ember-functional-modifiers": "^0.2.0"
+    "ember-modifier-manager-polyfill": "^1.0.3"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/tests/integration/modifiers/style-test.js
+++ b/tests/integration/modifiers/style-test.js
@@ -90,10 +90,10 @@ module('Integration | Modifiers | style', function(hooks) {
 
     test('supports multiple hashes', async function(assert) {
       await render(
-        hbs`<p {{style (hash color="red" font-size="12px") (hash color="green")}}></p>`
+        hbs`<p {{style (hash display="inline" font-size="12px") (hash display="inline-block")}}></p>`
       );
 
-      assert.dom('p').hasStyle({ color: 'green', fontSize: '12px' });
+      assert.dom('p').hasStyle({ display: 'inline-block', fontSize: '12px' });
     });
 
     test('it supports dynamic property names', async function(assert) {

--- a/tests/integration/modifiers/style-test.js
+++ b/tests/integration/modifiers/style-test.js
@@ -88,6 +88,14 @@ module('Integration | Modifiers | style', function(hooks) {
       assert.dom('p').hasStyle({ fontSize: '12px', textAlign: 'right' });
     });
 
+    test('supports multiple hashes', async function(assert) {
+      await render(
+        hbs`<p {{style (hash color="red" font-size="12px") (hash color="green")}}></p>`
+      );
+
+      assert.dom('p').hasStyle({ color: 'green', fontSize: '12px' });
+    });
+
     test('it supports dynamic property names', async function(assert) {
       this.set('styles', { display: 'none' });
 

--- a/tests/integration/modifiers/style-test.js
+++ b/tests/integration/modifiers/style-test.js
@@ -15,77 +15,100 @@ module('Integration | Modifiers | style', function(hooks) {
   test('it sets style on element', async function(assert) {
     await render(hbs`<p {{style display="none"}}></p>`);
 
-    assert.dom('p').hasStyle({ display: "none" });
+    assert.dom('p').hasStyle({ display: 'none' });
   });
 
   test('it allows to set priority', async function(assert) {
     await render(hbs`<p {{style display="none !important"}}></p>`);
 
-    assert.dom('p').hasAttribute("style", "display: none !important;");
+    assert.dom('p').hasAttribute('style', 'display: none !important;');
   });
 
   test('it does not set custom style if value is undefined', async function(assert) {
     await render(hbs`<p {{style display=undefined}}></p>`);
 
-    assert.dom('p').hasNoAttribute("style");
+    assert.dom('p').hasNoAttribute('style');
   });
 
   test('it supports dasherized property name', async function(assert) {
     await render(hbs`<p {{style font-size="6px"}}></p>`);
 
-    assert.dom('p').hasStyle({ fontSize: "6px" });
+    assert.dom('p').hasStyle({ fontSize: '6px' });
   });
 
   test('it supports camelCase property name', async function(assert) {
     await render(hbs`<p {{style fontSize="6px"}}></p>`);
 
-    assert.dom('p').hasStyle({ fontSize: "6px" });
+    assert.dom('p').hasStyle({ fontSize: '6px' });
   });
 
   test('it supports String object', async function(assert) {
-    this.set('display', new String("none"));
+    this.set('display', new String('none'));
     await render(hbs`<p {{style display=display}}></p>`);
 
-    assert.dom('p').hasStyle({ display: "none" });
+    assert.dom('p').hasStyle({ display: 'none' });
   });
 
   test('it observers values for changes', async function(assert) {
     this.set('display', 'none');
     await render(hbs`<p {{style display=display}}></p>`);
 
-    assert.dom('p').hasStyle({ display: "none" });
+    assert.dom('p').hasStyle({ display: 'none' });
 
     this.set('display', 'inline');
-    assert.dom('p').hasStyle({ display: "inline" });
+    assert.dom('p').hasStyle({ display: 'inline' });
   });
 
   module('options hash', function() {
     test('it accepts an option hash as alternative to named arguments', async function(assert) {
       await render(hbs`<p {{style (hash display="none")}}></p>`);
 
-      assert.dom('p').hasStyle({ display: "none" });
+      assert.dom('p').hasStyle({ display: 'none' });
     });
 
     test('options hash and named arguments could be used together', async function(assert) {
       await render(hbs`<p {{style (hash padding="6px") margin="12px"}}></p>`);
 
-      assert.dom('p').hasStyle({ padding: "6px", margin: "12px" });
+      assert.dom('p').hasStyle({ padding: '6px', margin: '12px' });
     });
 
     test('named arguments overrule option hash', async function(assert) {
-      await render(hbs`<p {{style (hash display="none") display="inline"}}></p>`);
+      await render(
+        hbs`<p {{style (hash display="none") display="inline"}}></p>`
+      );
 
-      assert.dom('p').hasStyle({ display: "inline" });
+      assert.dom('p').hasStyle({ display: 'inline' });
+    });
+
+    test('differently dasherized named arguments overrule option hash', async function(assert) {
+      await render(
+        hbs`<p {{style (hash font-size="10px" textAlign="left") fontSize="12px" text-align="right"}}></p>`
+      );
+
+      assert.dom('p').hasStyle({ fontSize: '12px', textAlign: 'right' });
     });
 
     test('it supports dynamic property names', async function(assert) {
-      this.set('styles', { display: "none" });
+      this.set('styles', { display: 'none' });
 
       await render(hbs`<p {{style styles}}></p>`);
-      assert.dom('p').hasStyle({ display: "none" });
+      assert.dom('p').hasStyle({ display: 'none' });
 
       this.set('styles', {});
-      assert.dom('p').hasAttribute("style", "");
+      assert.dom('p').hasAttribute('style', '');
+    });
+
+    test('it correctly handles dasherization over time', async function(assert) {
+      this.set('styles', { 'font-size': '12px' });
+
+      await render(hbs`<p {{style styles}}></p>`);
+      assert.dom('p').hasStyle({ fontSize: '12px' });
+
+      this.set('styles', { fontSize: '10px' });
+      assert.dom('p').hasStyle({ fontSize: '10px' });
+
+      this.set('styles', {});
+      assert.dom('p').hasAttribute('style', '');
     });
   });
 
@@ -111,7 +134,7 @@ module('Integration | Modifiers | style', function(hooks) {
         assert.ok(true);
       };
 
-      await render(hbs`<p {{style padding=1}}></p>`)
+      await render(hbs`<p {{style padding=1}}></p>`);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,18 +64,6 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@babel/helper-create-class-features-plugin@^7.3.0", "@babel/helper-create-class-features-plugin@^7.3.4":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz#092711a7a3ad8ea34de3e541644c2ce6af1f6f0c"
-  integrity sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==
-  dependencies:
-    "@babel/helper-function-name" "^7.1.0"
-    "@babel/helper-member-expression-to-functions" "^7.0.0"
-    "@babel/helper-optimise-call-expression" "^7.0.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/helper-replace-supers" "^7.3.4"
-    "@babel/helper-split-export-declaration" "^7.0.0"
-
 "@babel/helper-define-map@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz#3b74caec329b3c80c116290887c0dd9ae468c20c"
@@ -239,23 +227,6 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.2.0"
 
-"@babel/plugin-proposal-class-properties@^7.1.0":
-  version "7.3.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.3.4.tgz#410f5173b3dc45939f9ab30ca26684d72901405e"
-  integrity sha512-lUf8D3HLs4yYlAo8zjuneLvfxN7qfKv1Yzbj5vjqaqMJxgJA3Ipwp4VUJ+OrOdz53Wbww6ahwB8UhB2HQyLotA==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.3.4"
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-proposal-decorators@^7.1.2":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.3.0.tgz#637ba075fa780b1f75d08186e8fb4357d03a72a7"
-  integrity sha512-3W/oCUmsO43FmZIqermmq6TKaRSYhmh/vybPfVFwQWdSb8xwki38uAIvknCRzuyHRuYfCYmJzL9or1v0AffPjg==
-  dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.3.0"
-    "@babel/helper-plugin-utils" "^7.0.0"
-    "@babel/plugin-syntax-decorators" "^7.2.0"
-
 "@babel/plugin-proposal-json-strings@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.2.0.tgz#568ecc446c6148ae6b267f02551130891e29f317"
@@ -293,13 +264,6 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.2.0.tgz#69e1f0db34c6f5a0cf7e2b3323bf159a76c8cb7f"
   integrity sha512-1ZrIRBv2t0GSlcwVoQ6VgSLpLgiN/FVQUzt9znxo7v2Ov4jJrs8RY8tv0wvDmFN3qIdMKWrmMMW6yZ0G19MfGg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0"
-
-"@babel/plugin-syntax-decorators@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz#c50b1b957dcc69e4b1127b65e1c33eef61570c1b"
-  integrity sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -661,16 +625,6 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-decorators/babel-transforms@^3.1.5":
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/babel-transforms/-/babel-transforms-3.1.5.tgz#6df543f7f1d862ad54d05555d548805e032f6514"
-  integrity sha512-dTcpIylGj+gU+GM3Se0mVn/NGcIFLDTJYE0h04WtBT+Szon8y0SKFPO4pyEz+NINNU6w+PRP/Y7GsT8txxdrYg==
-  dependencies:
-    "@babel/plugin-proposal-class-properties" "^7.1.0"
-    "@babel/plugin-proposal-decorators" "^7.1.2"
-    ember-cli-babel-plugin-helpers "^1.0.0"
-    ember-cli-version-checker "^2.1.0"
-
 "@ember/optional-features@^0.6.3":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.6.4.tgz#8199f853c1781234fcb1f05090cddd0b822bff69"
@@ -884,11 +838,6 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-regex@*, ansi-regex@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
-  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -898,6 +847,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -3011,7 +2965,7 @@ debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3190,11 +3144,6 @@ ember-assign-polyfill@~2.4.0:
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-version-checker "^2.0.0"
-
-ember-cli-babel-plugin-helpers@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.0.2.tgz#d4bec0f32febc530e621ea8d66d3365727cb5e6c"
-  integrity sha512-tTWmHiIvadgtu0i+Zlb5Jnue69qO6dtACcddkRhhV+m9NfAr+2XNoTKRSeGL8QyRDhfWeo4rsK9dqPrU4PQ+8g==
 
 ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.18.0"
@@ -3538,15 +3487,6 @@ ember-export-application-global@^2.0.0:
   integrity sha1-jW12GayKGj+MQwA1Sesh6+1oW9I=
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
-
-ember-functional-modifiers@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-functional-modifiers/-/ember-functional-modifiers-0.2.0.tgz#c82f29e49fbfeac50db11082b59494a86698ae84"
-  integrity sha512-jvI4dcdog9ApP8fq9QvYqdk6cQJFPGtmh6MKE75BcfzlCxUxFwgarMPdMcvy/kAoPDY8LXnvjl2AzjxZ2MjSZQ==
-  dependencies:
-    "@ember-decorators/babel-transforms" "^3.1.5"
-    ember-cli-babel "^7.1.2"
-    ember-modifier-manager-polyfill "^1.0.3"
 
 ember-load-initializers@^1.1.0:
   version "1.1.0"
@@ -5064,7 +5004,7 @@ ignore@^4.0.2, ignore@^4.0.3:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -5822,7 +5762,7 @@ lodash._basefor@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz#7550b4e9218ef09fad24343b612021c79b4c20c2"
   integrity sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=
 
-lodash._baseindexof@*, lodash._baseindexof@^3.0.0:
+lodash._baseindexof@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
   integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
@@ -5836,14 +5776,6 @@ lodash._baseisequal@^3.0.0:
     lodash.istypedarray "^3.0.0"
     lodash.keys "^3.0.0"
 
-lodash._baseuniq@*:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
-  integrity sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=
-  dependencies:
-    lodash._createset "~4.0.0"
-    lodash._root "~3.0.0"
-
 lodash._baseuniq@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz#2123fa0db2d69c28d5beb1c1f36d61522a740234"
@@ -5853,12 +5785,12 @@ lodash._baseuniq@^3.0.0:
     lodash._cacheindexof "^3.0.0"
     lodash._createcache "^3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
 
-lodash._cacheindexof@*, lodash._cacheindexof@^3.0.0:
+lodash._cacheindexof@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
   integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
@@ -5872,17 +5804,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*, lodash._createcache@^3.0.0:
+lodash._createcache@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
   integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
   dependencies:
     lodash._getnative "^3.0.0"
-
-lodash._createset@~4.0.0:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-  integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
 lodash._createwrapper@~2.3.0:
   version "2.3.0"
@@ -5905,7 +5832,7 @@ lodash._escapestringchar@~2.3.0:
   resolved "https://registry.yarnpkg.com/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz#cce73ae60fc6da55d2bf8a0679c23ca2bab149fc"
   integrity sha1-zOc65g/G2lXSv4oGecI8orqxSfw=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -5947,11 +5874,6 @@ lodash._reunescapedhtml@~2.3.0:
   dependencies:
     lodash._htmlescapes "~2.3.0"
     lodash.keys "~2.3.0"
-
-lodash._root@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
-  integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
 
 lodash._setbinddata@~2.3.0:
   version "2.3.0"
@@ -6078,15 +6000,10 @@ lodash.identity@~2.3.0:
   resolved "https://registry.yarnpkg.com/lodash.identity/-/lodash.identity-2.3.0.tgz#6b01a210c9485355c2a913b48b6711219a173ded"
   integrity sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0=
 
-lodash.isarguments@*, lodash.isarguments@^3.0.0:
+lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
   integrity sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=
-
-lodash.isarray@*:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"
-  integrity sha1-KspJayjEym1yZxUxNZDALm6jRAM=
 
 lodash.isarray@^3.0.0:
   version "3.0.4"
@@ -6109,11 +6026,6 @@ lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
   integrity sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=
-
-lodash.keys@*:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
-  integrity sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU=
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -6170,7 +6082,7 @@ lodash.pairs@^3.0.0:
   dependencies:
     lodash.keys "^3.0.0"
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
@@ -7591,7 +7503,7 @@ readable-stream@~2.0.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=
@@ -8495,13 +8407,6 @@ stringstream@~0.0.4:
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
   integrity sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==
 
-strip-ansi@*, strip-ansi@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.1.0.tgz#55aaa54e33b4c0649a7338a43437b1887d153ec4"
-  integrity sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==
-  dependencies:
-    ansi-regex "^4.1.0"
-
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -8515,6 +8420,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.1.0.tgz#55aaa54e33b4c0649a7338a43437b1887d153ec4"
+  integrity sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -9001,7 +8913,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
This PR removes `ember-functional-modifiers` and instead directly interacts with the manager / state bucket.

Fixes #7.