### PR TITLE
better assertion message for wrong value type

### DIFF
--- a/addon/modifiers/style.js
+++ b/addon/modifiers/style.js
@@ -31,7 +31,7 @@ function setStyles(element, newStyles, oldStyles) {
 
   newStyles.forEach(([property, value]) => {
     assert(
-      `Value must be a string or undefined, ${typeOf(value)} given`,
+      `Value must be a string or undefined. ${typeOf(value)} ("${value}") given for ${property}`,
       typeof value === 'undefined' || typeOf(value) === 'string'
     );
 

--- a/addon/modifiers/style.js
+++ b/addon/modifiers/style.js
@@ -31,7 +31,8 @@ function setStyles(element, newStyles, oldStyles) {
 
   newStyles.forEach(([property, value]) => {
     assert(
-      `Value must be a string or undefined. ${typeOf(value)} ("${value}") given for ${property}`,
+      `Your given value for property '${property}' is ${value} (${typeOf(value)}). ` +
+      'Accepted types are string and undefined. Please change accordingly.',
       typeof value === 'undefined' || typeOf(value) === 'string'
     );
 

--- a/tests/integration/modifiers/style-test.js
+++ b/tests/integration/modifiers/style-test.js
@@ -136,13 +136,14 @@ module('Integration | Modifiers | style', function(hooks) {
     });
 
     test('it throws if value is not a string', async function(assert) {
-      assert.expect(1);
-
-      Ember.onerror = function() {
-        assert.ok(true);
+      Ember.onerror = function({ message }) {
+        assert.step('assertion thrown');
+        assert.ok(message.includes('number'), 'message includes type of value');
+        assert.ok(message.includes('1'), 'message includes value');
       };
 
       await render(hbs`<p {{style padding=1}}></p>`);
+      assert.verifySteps(['assertion thrown']);
     });
   });
 });


### PR DESCRIPTION
This adds more information to assertion thrown if value of CSS declaration has a wrong type. Error message includes not only type of value but also value on property. E.g. `<p {{style padding=6}}></p>` throws `Assertion Failed: Value must be a string or undefined. number ("6") given for padding`.

Closes #9 