### PR TITLE
drop support for Ember < 3.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,9 @@
 #$ browsers:
 #$   - chrome
 #$ emberTryScenarios:
-#$   - scenario: ember-lts-3.8
+#$   - scenario: ember-lts-3.24
 #$     allowedToFail: false
-#$   - scenario: ember-lts-3.12
-#$     allowedToFail: false
-#$   - scenario: ember-lts-3.16
-#$     allowedToFail: false
-#$   - scenario: ember-lts-3.20
+#$   - scenario: ember-lts-3.28
 #$     allowedToFail: false
 #$   - scenario: ember-release
 #$     allowedToFail: false
@@ -187,10 +183,8 @@ jobs:
       fail-fast: true
       matrix:
         ember-try-scenario: [
-          ember-lts-3.8,
-          ember-lts-3.12,
-          ember-lts-3.16,
-          ember-lts-3.20,
+          ember-lts-3.24,
+          ember-lts-3.28,
           ember-release,
           ember-beta,
           ember-canary,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This allows to set custom CSS of an element without requiring a [Content Securit
 
 ## Compatibility
 
-* Ember.js v3.8 or above
+* Ember.js v3.24 or above
 * Ember CLI v2.13 or above
 * Node.js v12 or above
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,34 +7,18 @@ module.exports = async function () {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.8',
+        name: 'ember-lts-3.24',
         npm: {
           devDependencies: {
-            'ember-source': '~3.8.0',
+            'ember-source': '~3.24.0',
           },
         },
       },
       {
-        name: 'ember-lts-3.12',
+        name: 'ember-lts-3.28',
         npm: {
           devDependencies: {
-            'ember-source': '~3.12.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.20',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.20.5',
+            'ember-source': '~3.28.0',
           },
         },
       },


### PR DESCRIPTION
This allows us to upgrade Ember Modifier to v3 (#60).