### PR TITLE
Resolve `ember-modifier` deprecations

### DIFF
--- a/addon/modifiers/style.js
+++ b/addon/modifiers/style.js
@@ -21,9 +21,7 @@ export default class StyleModifier extends Modifier {
    *
    * This data structure is slightly faster to process than an object / dictionary.
    */
-  get styles() {
-    const { positional, named } = this.args;
-
+  getStyles(positional, named) {
     // This is a workaround for the missing `Array#flat` in IE11.
     return [].concat(
       ...[...positional.filter(isObject), named].map((obj) =>
@@ -32,7 +30,7 @@ export default class StyleModifier extends Modifier {
     );
   }
 
-  setStyles(newStyles) {
+  setStyles(element, newStyles) {
     const rulesToRemove = this._oldStyles || new Set();
 
     newStyles.forEach(([property, value]) => {
@@ -56,20 +54,20 @@ export default class StyleModifier extends Modifier {
       property = dasherize(property);
 
       // update CSSOM
-      this.element.style.setProperty(property, value, priority);
+      element.style.setProperty(property, value, priority);
 
       // should not remove rules that have been updated in this cycle
       rulesToRemove.delete(property);
     });
 
     // remove rules that were present in last cycle but aren't present in this one
-    rulesToRemove.forEach((rule) => this.element.style.removeProperty(rule));
+    rulesToRemove.forEach((rule) => element.style.removeProperty(rule));
 
     // cache styles that in this rendering cycle for the next one
     this._oldStyles = new Set(newStyles.map((e) => e[0]));
   }
 
-  didReceiveArguments() {
-    this.setStyles(this.styles);
+  modify(element, positional, named) {
+    this.setStyles(element, this.getStyles(positional, named));
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
-    "ember-modifier": "^3.0.0"
+    "ember-modifier": "^3.2.7"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4900,10 +4900,10 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
-ember-cli-typescript@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.2.1.tgz#54d08fc90318cc986f3ea562f93ce58a6cc4c24d"
-  integrity sha512-0iKTZ+/wH6UB/VTWKvGuXlmwiE8HSIGcxHamwNhEC5x1mN3z8RfvsFZdQWYUzIWFN2Tek0gmepGRPTwWdBYl/A==
+ember-cli-typescript@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-5.0.0.tgz#52f53843082d0a0128f318809dadabf83a76bbff"
+  integrity sha512-UDKZlG7bInRo7eDsF3jvPz1Dxh1YvRhMw9wyj5rj2K3brw0xEh1IMTqPgWRbPESqjcWuwa8s0FCNuYWDc4PTfg==
   dependencies:
     ansi-to-html "^0.6.15"
     broccoli-stew "^3.0.0"
@@ -5086,15 +5086,15 @@ ember-maybe-import-regenerator@^1.0.0:
     ember-cli-babel "^7.26.6"
     regenerator-runtime "^0.13.2"
 
-ember-modifier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.0.0.tgz#74466d32e4ef9b80004915676cc3bfd6e3fd7a3d"
-  integrity sha512-ccXfMnjWhjEUCB5taeIPQmf0h1zPUIMbmsCV7W+JZ2BioPUZTLhE1WuHspmV0iEOiX3Fwx8jMOx6b74sFcKJ0g==
+ember-modifier@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-3.2.7.tgz#f2d35b7c867cbfc549e1acd8d8903c5ecd02ea4b"
+  integrity sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==
   dependencies:
     ember-cli-babel "^7.26.6"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-typescript "^4.2.1"
+    ember-cli-typescript "^5.0.0"
     ember-compatibility-helpers "^1.2.5"
 
 ember-page-title@^7.0.0:


### PR DESCRIPTION
The console is still flooded with deprecations, but I think these are triggered incorrectly.
More info: https://github.com/ember-modifier/ember-modifier/issues/282.

Closes #87.