### PR TITLE
Add `@ember/string` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@ember/string": "^3.0.1",
     "ember-cli-babel": "^7.26.11",
     "ember-auto-import": "^2.4.2",
     "ember-modifier": "^3.2.7 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@ember/string": "^3.0.1",
     "ember-cli-babel": "^7.26.11",
     "ember-auto-import": "^2.4.2",
     "ember-modifier": "^3.2.7 || ^4.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.8.1",
     "@embroider/test-setup": "^2.0.0",
     "@glimmer/component": "^1.1.2",
@@ -70,6 +70,9 @@
     "release-it": "^15.0.0",
     "release-it-lerna-changelog": "^5.0.0",
     "webpack": "^5.74.0"
+  },
+  "peerDependencies": {
+    "@ember/string": "^3.0.1"
   },
   "engines": {
     "node": "14.* || >= 16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,13 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
+"@ember/string@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/string/-/string-3.0.1.tgz#42cf032031a4432c2dd69c327ae1876d2c13df9c"
+  integrity sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==
+  dependencies:
+    ember-cli-babel "^7.26.6"
+
 "@ember/test-helpers@^2.8.1":
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.9.3.tgz#c2a9d6ab1c367af92cf1a334f97eb19b8e06e6e1"


### PR DESCRIPTION
To fix Ember 4.10 [deprecation](https://deprecations.emberjs.com/v4.x/#toc_ember-string-add-package) warnings.

Similar to https://github.com/ember-cli/ember-resolver/pull/862.

cc @jelhan