### PR TITLE
Don't dasherize property names twice

### DIFF
--- a/addon/modifiers/style.js
+++ b/addon/modifiers/style.js
@@ -53,9 +53,6 @@ export default class StyleModifier extends Modifier {
         value = value.replace('!important', '');
       }
 
-      // support camelCase property name
-      property = dasherize(property);
-
       // update CSSOM
       element.style.setProperty(property, value, priority);
 


### PR DESCRIPTION
Hey there. This package is awesome! Much nicer than using inline style strings. 

I noticed in the source code, it looks like dasherize is being called twice? Once in `compileStyles`, and again in `StyleModifier#setStyles`. Since `setStyles` only ever gets passed the return value of `compileStyles`, I think the second call to `dasherize` is unnecessary. But feel free to ignore this if I'm missing something. 

Thanks again for this package.