### PR TITLE
document Ember compatibility adding a peer dep on ember-source

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@ember/string": "^3.0.1"
+    "@ember/string": "^3.0.1",
+    "ember-source": ">= 4.12.0"
   },
   "engines": {
     "node": "18.* || >= 20"


### PR DESCRIPTION
This is not a breaking change. Ember Style Modifier was already documented to only support Ember >= 4.12.0. It only helps consumers to detect early if they are using an unsupported Ember version.