### PR TITLE
improve typing of CSS styles using csstype package

### DIFF
--- a/addon/modifiers/style.ts
+++ b/addon/modifiers/style.ts
@@ -2,12 +2,13 @@ import Modifier from 'ember-modifier';
 import { dasherize } from '@ember/string';
 import { assert } from '@ember/debug';
 import { typeOf } from '@ember/utils';
+import type * as CSS from 'csstype';
 
 // Cannot be typed as `Partial<CSSStyleDeclaration>` because `CSSStyleDeclaration`
 // interface does _not_ included dashed CSS property names. It only includes the
 // camelCase version of a CSS property.
 // https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1672
-type CSSStyles = { [key: string]: string | undefined };
+type CSSStyles = Partial<CSS.Properties> | Partial<CSS.PropertiesHyphen>;
 
 function isObject(o: unknown): boolean {
   return typeof o === 'object' && Boolean(o);

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.23.6",
+    "csstype": "^3.1.3",
     "ember-auto-import": "^2.7.0",
     "ember-cli-babel": "^8.2.0",
     "ember-modifier": "^3.2.7 || ^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@babel/core':
     specifier: ^7.23.6
     version: 7.23.7
+  csstype:
+    specifier: ^3.1.3
+    version: 3.1.3
   ember-auto-import:
     specifier: ^2.7.0
     version: 2.7.2(@glint/template@1.2.2)(webpack@5.89.0)
@@ -5080,6 +5083,10 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  /csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+    dev: false
 
   /dag-map@2.0.2:
     resolution: {integrity: sha512-xnsprIzYuDeiyu5zSKwilV/ajRHxnoMlAhEREfyfTgTSViMVY2fGP1ZcHJbtwup26oCkofySU/m6oKJ3HrkW7w==}

--- a/tests/integration/modifiers/style-test.ts
+++ b/tests/integration/modifiers/style-test.ts
@@ -13,6 +13,12 @@ module('Integration | Modifiers | style', function (hooks) {
     assert.dom('p').hasStyle({ display: 'none' });
   });
 
+  test('it supports multiple styles', async function (assert) {
+    await render(hbs`<p {{style display="none" float="left"}}></p>`);
+
+    assert.dom('p').hasStyle({ display: 'none', float: 'left' });
+  });
+
   test('it allows to set priority', async function (assert) {
     await render(hbs`<p {{style display="none !important"}}></p>`);
 
@@ -35,6 +41,15 @@ module('Integration | Modifiers | style', function (hooks) {
     await render(hbs`<p {{style fontSize="6px"}}></p>`);
 
     assert.dom('p').hasStyle({ fontSize: '6px' });
+  });
+
+  test('it supports dasherized and camelCase property names in same declaration', async function (assert) {
+    await render(hbs`<p {{style font-size="6px" fontStyle="italic"}}></p>`);
+
+    assert
+      .dom('p')
+      .hasStyle({ fontSize: '6px' })
+      .hasStyle({ fontStyle: 'italic' });
   });
 
   {


### PR DESCRIPTION
Improves the typing for CSS styles using the [`csstype`](https://www.npmjs.com/package/csstype) package.

In case you are running into an issue that a valid CSS style is _not_ allowed by the types, please update the indirect `csstype` dependency to a latest version. E.g. you could do so by regenerating the lockfile. If that does not help, the `csstype` package provides documentation how to deal with that situations: https://www.npmjs.com/package/csstype#what-should-i-do-when-i-get-type-errors

Thanks a lot to @boris-petrov for suggesting this [via Discord](https://discord.com/channels/480462759797063690/1194765499351969932/1194904244915028029).