### PR TITLE
Support Ember 3.28 and above (again)

### DIFF
--- a/ember-style-modifier/README.md
+++ b/ember-style-modifier/README.md
@@ -9,8 +9,8 @@ This allows to set custom CSS of an element without requiring a [Content Securit
 
 ## Compatibility
 
-* Ember.js v4.12 or above
-* Ember CLI v4.12 or above
+* Ember.js v3.28 or above
+* Ember CLI v3.28 or above
 * Node.js v18 or above
 
 ## Installation


### PR DESCRIPTION
Support for Ember < 4.12 had been dropped in v4.0.0. This adds back the support for Ember 3.28 and above.

Thanks a lot to @mkszepp for doing the work in #218.

Please be aware that I consider it limited support. Support for Ember < 4.12 needs to be provided by those needing to support such Ember versions, which only reached end of life.