### PR TITLE
Also allow using the modifier on SVG elements (types only)

### DIFF
--- a/ember-style-modifier/src/modifiers/style.ts
+++ b/ember-style-modifier/src/modifiers/style.ts
@@ -44,7 +44,7 @@ function compileStyles(
 }
 
 export interface StyleModifierSignature {
-  Element: HTMLElement;
+  Element: Element & ElementCSSInlineStyle;
   Args: {
     Positional: CSSStyles[];
     Named: CSSStyles;
@@ -54,7 +54,10 @@ export interface StyleModifierSignature {
 export default class StyleModifier extends Modifier<StyleModifierSignature> {
   existingStyles: Set<string> = new Set();
 
-  setStyles(element: HTMLElement, newStyles: [string, string][]) {
+  setStyles(
+    element: StyleModifierSignature['Element'],
+    newStyles: [string, string][],
+  ) {
     const { existingStyles } = this;
     const rulesToRemove: Set<string> = new Set(existingStyles);
 
@@ -92,7 +95,11 @@ export default class StyleModifier extends Modifier<StyleModifierSignature> {
     rulesToRemove.forEach((rule) => element.style.removeProperty(rule));
   }
 
-  modify(element: HTMLElement, positional: [CSSStyles] | [], named: CSSStyles) {
+  modify(
+    element: StyleModifierSignature['Element'],
+    positional: [CSSStyles] | [],
+    named: CSSStyles,
+  ) {
     this.setStyles(element, compileStyles(positional, named));
   }
 }

--- a/test-app/tests/integration/modifiers/style-test.ts
+++ b/test-app/tests/integration/modifiers/style-test.ts
@@ -60,6 +60,12 @@ module('Integration | Modifiers | style', function (hooks) {
     assert.dom('p').hasStyle({ fontSize: '6px' });
   });
 
+  test('it supports usage on SVG elements', async function (assert) {
+    await render(hbs`<svg {{style display="none"}}></svg>`);
+
+    assert.dom('svg').hasStyle({ display: 'none' });
+  });
+
   {
     interface Context extends TestContext {
       // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
Sorry, one more change. :smile: 

The `lint:types` task fails locally on my side (unrelated to this change). Not sure what I'm doing wrong but I hope here it will be fine.

cc @jelhan