### PR TITLE
Ensure modifier supports `math` elements

### DIFF
--- a/tests/integration/modifiers/style-test.gts
+++ b/tests/integration/modifiers/style-test.gts
@@ -104,6 +104,16 @@ module('Integration | Modifiers | style', function (hooks) {
     assert.dom('svg').hasStyle({ display: 'none' });
   });
 
+  test('it supports usage on math elements', async function (assert) {
+    await render(
+      <template>
+        <math {{style math-style="normal"}}></math>
+      </template>,
+    );
+
+    assert.dom('math').hasStyle({ 'math-style': 'normal' });
+  });
+
   {
     test('it supports String object', async function (this, assert) {
       const display = new String('none');


### PR DESCRIPTION
Cannot be merged right now because Glint doesn't seem to mark `math` elements as `MathMLElement`. See discussion in #235.