### PR TITLE
@babel/core dependency is not needed

### DIFF
--- a/ember-style-modifier/package.json
+++ b/ember-style-modifier/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@embroider/addon-shim": "^1.8.7",
     "decorator-transforms": "^1.0.1",
-    "@babel/core": "^7.23.6",
     "csstype": "^3.1.3",
     "ember-modifier": "^3.2.7 || ^4.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
 
   ember-style-modifier:
     dependencies:
-      '@babel/core':
-        specifier: ^7.23.6
-        version: 7.23.9
       '@ember/string':
         specifier: ^3.0.1
         version: 3.1.1
@@ -54,6 +51,9 @@ importers:
         specifier: ^3.28.0 || ^4.0.0 || >=5.0.0
         version: 5.6.0(@babel/core@7.23.9)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.90.0)
     devDependencies:
+      '@babel/core':
+        specifier: ^7.23.6
+        version: 7.23.9
       '@babel/plugin-transform-typescript':
         specifier: ^7.23.6
         version: 7.23.6(@babel/core@7.23.9)


### PR DESCRIPTION
I assume a leftover from when this was a v1 addon?