### PR TITLE
run tests against Ember v5.12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           - ember-lts-4.4
           - ember-lts-4.8
           - ember-lts-4.12
-          - ember-lts-5.4
+          - ember-lts-5.12
           - ember-release
           - ember-beta
           - ember-canary

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -46,10 +46,10 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-lts-5.4',
+        name: 'ember-lts-5.12',
         npm: {
           devDependencies: {
-            'ember-source': '~5.4.0',
+            'ember-source': '~5.12.0',
           },
         },
       },


### PR DESCRIPTION
The test app uses Ember v5.12 today: https://github.com/jelhan/ember-style-modifier/blob/d52a6455cbf5d76019a9bd11f5bcaf54a91f7578/test-app/package.json#L85 But that might change soonish. We should ensure that tests are still run against that important release even after upgrading the Ember version in the test-app.