### PR TITLE
Remove unneeded peer dependency on ember-source

### DIFF
--- a/ember-style-modifier/package.json
+++ b/ember-style-modifier/package.json
@@ -117,7 +117,6 @@
     }
   },
   "peerDependencies": {
-    "@ember/string": "^3.1.1 || ^4.0.0",
-    "ember-source": "^3.28.0 || ^4.0.0 || >=5.0.0"
+    "@ember/string": "^3.1.1 || ^4.0.0"
   }
 }


### PR DESCRIPTION
embroider, auto-import, and ember-cli before them handled virtual deps without a package.json entry.

package.json entries win over virtual deps, so we don't want to declare ember-source or @glimmer/tracking as peers.


Related:
- https://github.com/ember-polyfills/ember-functions-as-helper-polyfill/pull/151
- https://github.com/jelhan/ember-style-modifier/pull/312
- https://github.com/jmurphyau/ember-truth-helpers/pull/211
- https://github.com/ember-modifier/ember-modifier/pull/949
- https://github.com/tracked-tools/tracked-toolbox/pull/211
- https://github.com/emberjs/ember-test-helpers/pull/1543
- https://github.com/NullVoxPopuli/ember-resources/pull/1189
- https://github.com/NullVoxPopuli/ember-modify-based-class-resource/pull/20
- https://github.com/universal-ember/kolay/pull/187
- https://github.com/universal-ember/reactiveweb/pull/139
- https://github.com/universal-ember/ember-primitives/pull/471
- https://github.com/universal-ember/docs-support/pull/77
